### PR TITLE
refactor: (dev-server) prebuild icon package

### DIFF
--- a/dev-server/vite.config.ts
+++ b/dev-server/vite.config.ts
@@ -64,7 +64,7 @@ export default defineConfig(() => {
       }
     },
     optimizeDeps: {
-      include: ['../components']
+      include: ['../components', '@vexip-ui/icons']
     },
     plugins: [
       vue(),

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -39,6 +39,9 @@ export default defineConfig(({ command }) => {
       ],
       dedupe: useServer ? ['../components', 'vue'] : ['vue']
     },
+    optimizeDeps: {
+      include: ['@vexip-ui/icons']
+    },
     server: {
       port: 9000,
       host: '0.0.0.0',


### PR DESCRIPTION
When I was debugging a component, the first time the dev server started, the page loaded over 4000 modules. It takes more than 6s.