### PR TITLE
chore: fix the vitest config path error

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,9 +4,11 @@ import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 
-const dirs = readdirSync(__dirname).filter(f => statSync(resolve(f)).isDirectory())
+const rootDir = __dirname
+const dirs = readdirSync(__dirname).filter(f => statSync(resolve(rootDir, f)).isDirectory())
 
 export default defineConfig({
+  root: rootDir,
   resolve: {
     alias: [
       { find: /^@\/(.+)/, replacement: resolve(__dirname, '$1') },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/vexip-ui/vexip-ui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
<!-- Clear and concise description of what the PR is solving. -->
![image](https://user-images.githubusercontent.com/96854855/234287433-2652638b-bb54-426b-8e5d-aa7aae34f5d5.png)
fix the error when run npx vitest not in the root dir
### Linked Issues
<!-- Fix #123. Fix #666. -->

### Additional Context
<!-- Any other context or screenshots about the PR here. -->
