### PR TITLE
fix(color-picker): incorrect getFormattedColor function name

### DIFF
--- a/components/color-picker/color-picker.vue
+++ b/components/color-picker/color-picker.vue
@@ -494,7 +494,7 @@ export default defineComponent({
       handleChange()
     }
 
-    function getForamttedColor() {
+    function getFormattedColor() {
       let color: Color
 
       if (props.format === 'hex') {
@@ -540,7 +540,7 @@ export default defineComponent({
     }
 
     function handleChange() {
-      const formattedColor = getForamttedColor()
+      const formattedColor = getFormattedColor()
 
       setFieldValue(formattedColor)
       emitEvent(props.onChange, formattedColor)
@@ -574,7 +574,7 @@ export default defineComponent({
       currentValue.value = rgbToHsv(r, g, b)
       currentAlpha.value = a
 
-      emitEvent(props.onShortcut, getForamttedColor())
+      emitEvent(props.onShortcut, getFormattedColor())
     }
 
     function toggleEditing(able: boolean) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/vexip-ui/vexip-ui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Clear and concise description of what the PR is solving. -->

incorrect getFormattedColor function name

_A little PR for typos can go up. I'll do my best to deal with it all at once._

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->
