### PR TITLE
chore(select): rename no-preview prop to preview

### DIFF
--- a/components/select/props.ts
+++ b/components/select/props.ts
@@ -70,7 +70,7 @@ export const selectProps = buildProps({
   maxTagCount: Number,
   noRestTip: booleanProp,
   tagType: String as PropType<TagType>,
-  noPreview: booleanProp,
+  preview: booleanProp,
   remote: booleanProp,
   onFocus: eventProp<(event: FocusEvent) => void>(),
   onBlur: eventProp<(event: FocusEvent) => void>(),

--- a/components/select/select.vue
+++ b/components/select/select.vue
@@ -417,7 +417,7 @@ export default defineComponent({
       maxTagCount: 0,
       noRestTip: false,
       tagType: null,
-      noPreview: false,
+      preview: false,
       remote: false
     })
 
@@ -688,7 +688,7 @@ export default defineComponent({
       return !props.disabled && props.clearable && isHover.value && hasValue.value
     })
     const hittingLabel = computed(() => {
-      return !props.noPreview && currentVisible.value ? hittingOption.value?.label : undefined
+      return !props.preview && currentVisible.value ? hittingOption.value?.label : undefined
     })
 
     function getOptionFromMap(value?: string | number | null) {

--- a/docs/en-US/component/select.md
+++ b/docs/en-US/component/select.md
@@ -235,7 +235,7 @@ type SelectFilter = (value: string | number, options: SelectOptionState) => bool
 | no-rest-tip     | `boolean`                                        | Set whether to disable the bubble tip for extra tabs                                                                                                          | `false`        | `2.1.0`  |
 | tag-type        | `TagType`                                        | Set the type of label in multi-select mode                                                                                                                    | `null`         | `2.1.0`  |
 | locale          | `LocaleConfig['select']`                         | Set the locale config                                                                                                                                         | `null`         | `2.1.0`  |
-| no-preview      | `boolean`                                        | Set whether to disable the option label dynamic preview                                                                                                       | `false`        | `2.1.10` |
+| preview         | `boolean`                                        | Set whether to disable the option label dynamic preview                                                                                                       | `false`        | `2.1.10` |
 | remote          | `boolean`                                        | Whether to enable remote mode                                                                                                                                 | `false`        | `2.1.12` |
 
 ### Select Events

--- a/docs/zh-CN/component/select.md
+++ b/docs/zh-CN/component/select.md
@@ -231,7 +231,7 @@ type SelectFilter = (value: string | number, options: SelectOptionState) => bool
 | no-rest-tip     | `boolean`                                        | 设置是否禁用额外标签的气泡提示                                            | `false`        | `2.1.0`  |
 | tag-type        | `TagType`                                        | 设置多选模式下标签的类型                                                  | `null`         | `2.1.0`  |
 | locale          | `LocaleConfig['select']`                         | 设置多语言配置                                                            | `null`         | `2.1.0`  |
-| no-preview      | `boolean`                                        | 设置是否禁用选项标签动态预览功能                                          | `false`        | `2.1.10` |
+| preview         | `boolean`                                        | 设置是否禁用选项标签动态预览功能                                          | `false`        | `2.1.10` |
 | remote          | `boolean`                                        | 是否开启远程模式                                                          | `false`        | `2.1.12` |
 
 ### Select 事件


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/vexip-ui/vexip-ui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

rename no-preview prop to preview

when the no-preview prop value is true it will show preview, this seems a bit contradictory

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->
