### PR TITLE
feat(select): add prop popperFitSelectWidth

### DIFF
--- a/components/select/props.ts
+++ b/components/select/props.ts
@@ -1,4 +1,5 @@
 import {
+  booleanNumberProp,
   booleanProp,
   booleanStringProp,
   buildProps,
@@ -72,6 +73,7 @@ export const selectProps = buildProps({
   tagType: String as PropType<TagType>,
   noPreview: booleanProp,
   remote: booleanProp,
+  popperFitSelectWidth: booleanNumberProp,
   onFocus: eventProp<(event: FocusEvent) => void>(),
   onBlur: eventProp<(event: FocusEvent) => void>(),
   onToggle: eventProp<(visible: boolean) => void>(),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/vexip-ui/vexip-ui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

add prop popperFitSelectWidth default is false

basic use:

1. popperFitSelectWidth === true

the popper width will equal select width

2. popperFitSelectWidth === false

just like the original

3. popperFitSelectWidth === number

set the popper width

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->
