### PR TITLE
style(collapse): adjust the border radius of the last panel of a card type

### DIFF
--- a/style/collapse.scss
+++ b/style/collapse.scss
@@ -189,7 +189,7 @@ $collapse: map.merge(
       border-bottom: 0;
 
       #{$header} {
-        border-radius: 0 0 $radius $radius;
+        border-radius: 0;
       }
     }
   }

--- a/style/collapse.scss
+++ b/style/collapse.scss
@@ -189,7 +189,7 @@ $collapse: map.merge(
       border-bottom: 0;
 
       #{$header} {
-        border-radius: 0;
+        border-radius: 0 0 $radius $radius;
       }
     }
   }
@@ -201,6 +201,10 @@ $collapse: map.merge(
 
     #{$content} {
       border-radius: 0 0 $radius $radius;
+    }
+
+    &:last-child #{$header} {
+      border-radius: 0;
     }
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/vexip-ui/vexip-ui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Clear and concise description of what the PR is solving. -->

adjust the border radius of the last panel of a card type

#### Before

<img width="386" alt="image" src="https://github.com/vexip-ui/vexip-ui/assets/27342882/15040546-8847-4665-91c5-08265b64fc70">

#### After

<img width="401" alt="image" src="https://github.com/vexip-ui/vexip-ui/assets/27342882/bba1d036-0896-4d5e-987c-376a94d5f387">

### Linked Issues

<!-- Fix #123. Fix #666. -->

### Additional Context

<!-- Any other context or screenshots about the PR here. -->
