### PR TITLE
feat(plugins): add transformLogical postcss plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,5 +76,8 @@ jobs:
       - name: Test utils
         run: pnpm -C common/utils test
 
+      - name: Test plugins
+        run: pnpm -C common/plugins test
+
       - name: Test
         run: pnpm run test

--- a/common/plugins/README.md
+++ b/common/plugins/README.md
@@ -1,3 +1,21 @@
 # @vexip-ui/plugins
 
 This package provides common plugins for vexip-ui components, it is published as a package that can be used standalone.
+
+## VexipUIResolver
+
+A resolver for `unplugin-vue-components` and `unplugin-auto-import`.
+
+```ts
+VexipUIResolver({ fullStyle: DEV_MODE })
+```
+
+## transformLogical
+
+A postcss plugin to transform logical properties/values back to their physical properties/values.
+
+```ts
+transformLogical({ replace: true })
+```
+
+> Because it's NOT a common postcss plugin project, you need to manually import the plugin if you're using postcss config file.

--- a/common/plugins/package.json
+++ b/common/plugins/package.json
@@ -4,7 +4,10 @@
   "license": "MIT",
   "anchor": "qmhc",
   "scripts": {
-    "build": "tsx scripts/build.ts"
+    "build": "tsx scripts/build.ts",
+    "test": "vitest run",
+    "test:cover": "vitest run --coverage",
+    "test:dev": "vitest dev"
   },
   "type": "module",
   "main": "dist/index.cjs",

--- a/common/plugins/package.json
+++ b/common/plugins/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.3",
+    "postcss": "^8.4.32",
     "tsup": "^8.0.1",
     "unplugin-vue-components": "^0.26.0"
   }

--- a/common/plugins/src/index.ts
+++ b/common/plugins/src/index.ts
@@ -1,1 +1,2 @@
+export * from './postcss-transform-logical'
 export * from './unplugin-vue-components'

--- a/common/plugins/src/postcss-transform-logical.ts
+++ b/common/plugins/src/postcss-transform-logical.ts
@@ -1,0 +1,216 @@
+import type { Declaration } from 'postcss'
+
+export interface TransformLogicalOptions {
+  /**
+   * Transform `start` to `right`, `end` to `left` if enabled, and will replace the original declaration
+   *
+   * @default false
+   */
+  rtl?: boolean,
+  /**
+   * Whether to replace the original declaration
+   *
+   * @default false
+   */
+  replace?: boolean
+}
+
+function transformLogical(options: TransformLogicalOptions = {}): import('postcss').Plugin {
+  const { rtl = false, replace = false } = options
+
+  const FLOW_BASE = '((?:inline|block))(-((?:start|end)))?'
+
+  const sizeRE = /(((?:min|max))-)?((?:inline|block))-size/i
+  const insetRE = new RegExp(`inset-${FLOW_BASE}`, 'i')
+  const paddingRE = new RegExp(`padding-${FLOW_BASE}`, 'i')
+  const marginRE = new RegExp(`margin-${FLOW_BASE}`, 'i')
+  const borderRE = new RegExp(`border-${FLOW_BASE}(-((?:width|style|color)))?`, 'i')
+  const radiusRE = /border-((?:start|end)-(?:start|end))-radius/i
+
+  const valueRE = /(?:caption-side|float|clear|text-align)/i
+
+  const sizeProp = {
+    inline: 'width',
+    block: 'height'
+  }
+  const inlineBaseProp = rtl
+    ? {
+        start: 'right',
+        end: 'left'
+      }
+    : {
+        start: 'left',
+        end: 'right'
+      }
+  const blockBaseProp = {
+    start: 'top',
+    end: 'bottom'
+  }
+
+  function splitValue(value: string) {
+    const values: string[] = []
+
+    let text = ''
+    const lastChar = ''
+    let bracket = 0
+
+    for (let i = 0, len = value.length; i < len; ++i) {
+      const char = value.charAt(i)
+      text += char
+
+      if (char === '(') {
+        ++bracket
+      } else if (char === ')' && bracket > 0) {
+        --bracket
+      } else if (char === ' ' && lastChar !== ' ' && !bracket) {
+        values.push(text.trim())
+        text = ''
+      }
+    }
+
+    if ((text = text.trim())) {
+      values.push(text)
+    }
+
+    return values
+  }
+
+  const insert = !replace && !rtl
+
+  function processDecl(decl: Declaration, prop: string, value?: string) {
+    if (insert) {
+      decl.cloneBefore(value ? { prop, value } : { prop })
+    } else {
+      decl.replaceWith(decl.clone(value ? { prop, value } : { prop }))
+    }
+  }
+
+  function createProcess(
+    regexp: RegExp,
+    process: (matched: RegExpMatchArray, decl: Declaration) => void
+  ) {
+    return (decl: Declaration) => {
+      const matched = decl.prop.match(regexp)
+
+      return !!matched && (process(matched, decl), true)
+    }
+  }
+
+  const processSize = createProcess(sizeRE, (matched, decl) => {
+    const minmax = matched[2] as 'min' | 'max' | undefined
+    const boxType = matched[3] as 'inline' | 'block'
+
+    processDecl(decl, minmax ? `${minmax}-${sizeProp[boxType]}` : sizeProp[boxType], decl.value)
+  })
+
+  const normalProcess = (
+    prefix: 'margin' | 'padding' | null,
+    matched: RegExpMatchArray,
+    decl: Declaration
+  ) => {
+    const boxType = matched[1] as 'inline' | 'block'
+    const type = matched[3] as 'start' | 'end' | undefined
+    const usedPrefix = prefix ? `${prefix}-` : ''
+    const prop = boxType === 'inline' ? inlineBaseProp : blockBaseProp
+
+    if (!type) {
+      const [start, end] = splitValue(decl.value)
+
+      processDecl(decl, `${usedPrefix}${prop.start}`, start)
+      processDecl(decl, `${usedPrefix}${prop.end}`, end || start)
+    } else {
+      processDecl(decl, `${usedPrefix}${prop[type]}`)
+    }
+  }
+
+  const processInset = createProcess(insetRE, normalProcess.bind(null, null))
+  const processPadding = createProcess(paddingRE, normalProcess.bind(null, 'padding'))
+  const processMargin = createProcess(marginRE, normalProcess.bind(null, 'margin'))
+
+  const processBorder = createProcess(borderRE, (matched, decl) => {
+    const boxType = matched[1] as 'inline' | 'block'
+    const type = matched[3] as 'start' | 'end' | undefined
+    const unitType = matched[5] as 'width' | 'style' | 'color' | undefined
+    const prop = boxType === 'inline' ? inlineBaseProp : blockBaseProp
+
+    if (!type && !unitType) {
+      processDecl(decl, `border-${prop.start}`)
+      processDecl(decl, `border-${prop.end}`)
+    } else if (type && unitType) {
+      processDecl(decl, `border-${prop[type]}-${unitType}`)
+    } else if (type) {
+      processDecl(decl, `border-${prop[type]}`)
+    } else {
+      processDecl(decl, `border-${prop.start}-${unitType}`)
+      processDecl(decl, `border-${prop.end}-${unitType}`)
+    }
+  })
+
+  const radiusProp = rtl
+    ? {
+        'start-start': 'top-right',
+        'start-end': 'top-left',
+        'end-end': 'bottom-left',
+        'end-start': 'bottom-right'
+      }
+    : {
+        'start-start': 'top-left',
+        'start-end': 'top-right',
+        'end-end': 'bottom-right',
+        'end-start': 'bottom-left'
+      }
+
+  const processRadius = createProcess(radiusRE, (matched, decl) => {
+    const type = matched[1] as 'start-start' | 'start-end' | 'end-end' | 'end-start'
+
+    processDecl(decl, `border-${radiusProp[type]}-radius`)
+  })
+
+  const logicalValue = {
+    ...(rtl
+      ? {
+          'inline-start': 'right',
+          'inline-end': 'left'
+        }
+      : {
+          'inline-start': 'left',
+          'inline-end': 'right'
+        }),
+    'block-start': 'top',
+    'block-end': 'bottom'
+  }
+
+  const processValue = createProcess(valueRE, (_, decl) => {
+    processDecl(
+      decl,
+      decl.prop,
+      logicalValue[decl.value.trim() as keyof typeof logicalValue] || decl.value
+    )
+  })
+
+  const processes = [
+    processSize,
+    processInset,
+    processPadding,
+    processMargin,
+    processBorder,
+    processRadius,
+    processValue
+  ]
+
+  return {
+    postcssPlugin: 'transform-logical',
+    OnceExit(root) {
+      root.walkRules(rule => {
+        rule.walkDecls(decl => {
+          processes.some(process => process(decl))
+        })
+      })
+    }
+  }
+}
+
+const plugin = transformLogical as import('postcss').PluginCreator<TransformLogicalOptions>
+plugin.postcss = true
+
+export { plugin as transformLogical }

--- a/common/plugins/src/postcss-transform-logical.ts
+++ b/common/plugins/src/postcss-transform-logical.ts
@@ -51,7 +51,7 @@ function transformLogical(options: TransformLogicalOptions = {}): import('postcs
     const values: string[] = []
 
     let text = ''
-    const lastChar = ''
+    let lastChar = ''
     let bracket = 0
 
     for (let i = 0, len = value.length; i < len; ++i) {
@@ -66,6 +66,8 @@ function transformLogical(options: TransformLogicalOptions = {}): import('postcs
         values.push(text.trim())
         text = ''
       }
+
+      lastChar = char
     }
 
     if ((text = text.trim())) {

--- a/common/plugins/tests/postcss-transform-logical.spec.ts
+++ b/common/plugins/tests/postcss-transform-logical.spec.ts
@@ -10,8 +10,6 @@ describe('postcss-transform-logical', () => {
     return [`a { ${origin} }`, replace ? `a { ${insert} }` : `a { ${insert}; ${origin} }`] as const
   }
 
-  // let count = 1
-
   async function checkBase(processor: Processor, input: string, output: string) {
     it(input, async () => {
       const result = await processor.process(input, { from: undefined })
@@ -75,6 +73,11 @@ describe('postcss-transform-logical', () => {
     check(...buildStyle('border-start-end-radius: 10px', 'border-top-right-radius: 10px'))
     check(...buildStyle('border-end-end-radius: 10px', 'border-bottom-right-radius: 10px'))
     check(...buildStyle('border-end-start-radius: 10px', 'border-bottom-left-radius: 10px'))
+
+    check(...buildStyle('caption-side: block-start', 'caption-side: top'))
+    check(...buildStyle('float: inline-start', 'float: left'))
+    check(...buildStyle('clear: inline-start', 'clear: left'))
+    check(...buildStyle('text-align: inline-start', 'text-align: left'))
   })
 
   describe('replace: true', () => {
@@ -133,6 +136,11 @@ describe('postcss-transform-logical', () => {
     check(...style('border-start-end-radius: 10px', 'border-top-right-radius: 10px'))
     check(...style('border-end-end-radius: 10px', 'border-bottom-right-radius: 10px'))
     check(...style('border-end-start-radius: 10px', 'border-bottom-left-radius: 10px'))
+
+    check(...style('caption-side: block-start', 'caption-side: top'))
+    check(...style('float: inline-start', 'float: left'))
+    check(...style('clear: inline-start', 'clear: left'))
+    check(...style('text-align: inline-start', 'text-align: left'))
   })
 
   describe('rtl: true', () => {
@@ -191,5 +199,37 @@ describe('postcss-transform-logical', () => {
     check(...style('border-start-end-radius: 10px', 'border-top-left-radius: 10px'))
     check(...style('border-end-end-radius: 10px', 'border-bottom-left-radius: 10px'))
     check(...style('border-end-start-radius: 10px', 'border-bottom-right-radius: 10px'))
+
+    check(...style('caption-side: block-start', 'caption-side: top'))
+    check(...style('float: inline-start', 'float: right'))
+    check(...style('clear: inline-start', 'clear: right'))
+    check(...style('text-align: inline-start', 'text-align: right'))
+  })
+
+  describe('parse complex value', () => {
+    const check = checkBase.bind(null, postcss([transformLogical()]))
+
+    // cannot parse `10px 5px` variable value to `10px` and `5px`
+    check(...buildStyle('inset-inline: var(--offset)', 'left: var(--offset); right: var(--offset)'))
+    check(
+      ...buildStyle(
+        'inset-inline: calc(1px + 2px)',
+        'left: calc(1px + 2px); right: calc(1px + 2px)'
+      )
+    )
+    check(...buildStyle('inset-inline: calc(1px + 2px) 3px', 'left: calc(1px + 2px); right: 3px'))
+    check(...buildStyle('inset-inline: 1px calc(2 * 2px)', 'left: 1px; right: calc(2 * 2px)'))
+    check(
+      ...buildStyle(
+        'inset-inline: calc(1px + 2px) calc(2 * 2px)',
+        'left: calc(1px + 2px); right: calc(2 * 2px)'
+      )
+    )
+    check(
+      ...buildStyle(
+        'inset-inline: calc(1px + var(--offset)) 3px',
+        'left: calc(1px + var(--offset)); right: 3px'
+      )
+    )
   })
 })

--- a/common/plugins/tests/postcss-transform-logical.spec.ts
+++ b/common/plugins/tests/postcss-transform-logical.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+
+import postcss from 'postcss'
+import { transformLogical } from '../src/postcss-transform-logical'
+
+import type { Processor } from 'postcss'
+
+describe('postcss-transform-logical', () => {
+  function buildStyle(origin: string, insert: string, replace = false) {
+    return [`a { ${origin} }`, replace ? `a { ${insert} }` : `a { ${insert}; ${origin} }`] as const
+  }
+
+  // let count = 1
+
+  async function checkBase(processor: Processor, input: string, output: string) {
+    it(input, async () => {
+      const result = await processor.process(input, { from: undefined })
+
+      expect(result.warnings().length).toBe(0)
+      expect(result.css).toEqual(output)
+    })
+  }
+
+  describe('none options', () => {
+    const check = checkBase.bind(null, postcss([transformLogical()]))
+
+    check(...buildStyle('inline-size: 10px', 'width: 10px'))
+    check(...buildStyle('block-size: 10px', 'height: 10px'))
+    check(...buildStyle('min-inline-size: 10px', 'min-width: 10px'))
+    check(...buildStyle('min-block-size: 10px', 'min-height: 10px'))
+    check(...buildStyle('max-inline-size: 10px', 'max-width: 10px'))
+    check(...buildStyle('max-block-size: 10px', 'max-height: 10px'))
+
+    check(...buildStyle('inset-inline-start: 10px', 'left: 10px'))
+    check(...buildStyle('inset-inline-end: 10px', 'right: 10px'))
+    check(...buildStyle('inset-block-start: 10px', 'top: 10px'))
+    check(...buildStyle('inset-block-end: 10px', 'bottom: 10px'))
+    check(...buildStyle('inset-inline: 10px', 'left: 10px; right: 10px'))
+    check(...buildStyle('inset-block: 10px', 'top: 10px; bottom: 10px'))
+    ;['padding', 'margin'].forEach(prefix => {
+      check(...buildStyle(`${prefix}-inline-start: 10px`, `${prefix}-left: 10px`))
+      check(...buildStyle(`${prefix}-inline-end: 10px`, `${prefix}-right: 10px`))
+      check(...buildStyle(`${prefix}-block-start: 10px`, `${prefix}-top: 10px`))
+      check(...buildStyle(`${prefix}-block-end: 10px`, `${prefix}-bottom: 10px`))
+      check(...buildStyle(`${prefix}-inline: 10px`, `${prefix}-left: 10px; ${prefix}-right: 10px`))
+      check(...buildStyle(`${prefix}-block: 10px`, `${prefix}-top: 10px; ${prefix}-bottom: 10px`))
+    })
+
+    check(...buildStyle('border-inline-start: 10px', 'border-left: 10px'))
+    check(...buildStyle('border-inline-end: 10px', 'border-right: 10px'))
+    check(...buildStyle('border-block-start: 10px', 'border-top: 10px'))
+    check(...buildStyle('border-block-end: 10px', 'border-bottom: 10px'))
+    check(...buildStyle('border-inline: 10px', 'border-left: 10px; border-right: 10px'))
+    check(...buildStyle('border-block: 10px', 'border-top: 10px; border-bottom: 10px'))
+    ;['width', 'style', 'color'].forEach(unit => {
+      check(...buildStyle(`border-inline-start-${unit}: 10px`, `border-left-${unit}: 10px`))
+      check(...buildStyle(`border-inline-end-${unit}: 10px`, `border-right-${unit}: 10px`))
+      check(...buildStyle(`border-block-start-${unit}: 10px`, `border-top-${unit}: 10px`))
+      check(...buildStyle(`border-block-end-${unit}: 10px`, `border-bottom-${unit}: 10px`))
+      check(
+        ...buildStyle(
+          `border-inline-${unit}: 10px`,
+          `border-left-${unit}: 10px; border-right-${unit}: 10px`
+        )
+      )
+      check(
+        ...buildStyle(
+          `border-block-${unit}: 10px`,
+          `border-top-${unit}: 10px; border-bottom-${unit}: 10px`
+        )
+      )
+    })
+
+    check(...buildStyle('border-start-start-radius: 10px', 'border-top-left-radius: 10px'))
+    check(...buildStyle('border-start-end-radius: 10px', 'border-top-right-radius: 10px'))
+    check(...buildStyle('border-end-end-radius: 10px', 'border-bottom-right-radius: 10px'))
+    check(...buildStyle('border-end-start-radius: 10px', 'border-bottom-left-radius: 10px'))
+  })
+
+  describe('replace: true', () => {
+    const check = checkBase.bind(null, postcss([transformLogical({ replace: true })]))
+
+    const style = (input: string, output: string) => buildStyle(input, output, true)
+
+    check(...style('inline-size: 10px', 'width: 10px'))
+    check(...style('block-size: 10px', 'height: 10px'))
+    check(...style('min-inline-size: 10px', 'min-width: 10px'))
+    check(...style('min-block-size: 10px', 'min-height: 10px'))
+    check(...style('max-inline-size: 10px', 'max-width: 10px'))
+    check(...style('max-block-size: 10px', 'max-height: 10px'))
+
+    check(...style('inset-inline-start: 10px', 'left: 10px'))
+    check(...style('inset-inline-end: 10px', 'right: 10px'))
+    check(...style('inset-block-start: 10px', 'top: 10px'))
+    check(...style('inset-block-end: 10px', 'bottom: 10px'))
+    check(...style('inset-inline: 10px', 'left: 10px; right: 10px'))
+    check(...style('inset-block: 10px', 'top: 10px; bottom: 10px'))
+    ;['padding', 'margin'].forEach(prefix => {
+      check(...style(`${prefix}-inline-start: 10px`, `${prefix}-left: 10px`))
+      check(...style(`${prefix}-inline-end: 10px`, `${prefix}-right: 10px`))
+      check(...style(`${prefix}-block-start: 10px`, `${prefix}-top: 10px`))
+      check(...style(`${prefix}-block-end: 10px`, `${prefix}-bottom: 10px`))
+      check(...style(`${prefix}-inline: 10px`, `${prefix}-left: 10px; ${prefix}-right: 10px`))
+      check(...style(`${prefix}-block: 10px`, `${prefix}-top: 10px; ${prefix}-bottom: 10px`))
+    })
+
+    check(...style('border-inline-start: 10px', 'border-left: 10px'))
+    check(...style('border-inline-end: 10px', 'border-right: 10px'))
+    check(...style('border-block-start: 10px', 'border-top: 10px'))
+    check(...style('border-block-end: 10px', 'border-bottom: 10px'))
+    check(...style('border-inline: 10px', 'border-left: 10px; border-right: 10px'))
+    check(...style('border-block: 10px', 'border-top: 10px; border-bottom: 10px'))
+    ;['width', 'style', 'color'].forEach(unit => {
+      check(...style(`border-inline-start-${unit}: 10px`, `border-left-${unit}: 10px`))
+      check(...style(`border-inline-end-${unit}: 10px`, `border-right-${unit}: 10px`))
+      check(...style(`border-block-start-${unit}: 10px`, `border-top-${unit}: 10px`))
+      check(...style(`border-block-end-${unit}: 10px`, `border-bottom-${unit}: 10px`))
+      check(
+        ...style(
+          `border-inline-${unit}: 10px`,
+          `border-left-${unit}: 10px; border-right-${unit}: 10px`
+        )
+      )
+      check(
+        ...style(
+          `border-block-${unit}: 10px`,
+          `border-top-${unit}: 10px; border-bottom-${unit}: 10px`
+        )
+      )
+    })
+
+    check(...style('border-start-start-radius: 10px', 'border-top-left-radius: 10px'))
+    check(...style('border-start-end-radius: 10px', 'border-top-right-radius: 10px'))
+    check(...style('border-end-end-radius: 10px', 'border-bottom-right-radius: 10px'))
+    check(...style('border-end-start-radius: 10px', 'border-bottom-left-radius: 10px'))
+  })
+
+  describe('rtl: true', () => {
+    const check = checkBase.bind(null, postcss([transformLogical({ rtl: true })]))
+
+    const style = (input: string, output: string) => buildStyle(input, output, true)
+
+    check(...style('inline-size: 10px', 'width: 10px'))
+    check(...style('block-size: 10px', 'height: 10px'))
+    check(...style('min-inline-size: 10px', 'min-width: 10px'))
+    check(...style('min-block-size: 10px', 'min-height: 10px'))
+    check(...style('max-inline-size: 10px', 'max-width: 10px'))
+    check(...style('max-block-size: 10px', 'max-height: 10px'))
+
+    check(...style('inset-inline-start: 10px', 'right: 10px'))
+    check(...style('inset-inline-end: 10px', 'left: 10px'))
+    check(...style('inset-block-start: 10px', 'top: 10px'))
+    check(...style('inset-block-end: 10px', 'bottom: 10px'))
+    check(...style('inset-inline: 10px', 'right: 10px; left: 10px'))
+    check(...style('inset-block: 10px', 'top: 10px; bottom: 10px'))
+    ;['padding', 'margin'].forEach(prefix => {
+      check(...style(`${prefix}-inline-start: 10px`, `${prefix}-right: 10px`))
+      check(...style(`${prefix}-inline-end: 10px`, `${prefix}-left: 10px`))
+      check(...style(`${prefix}-block-start: 10px`, `${prefix}-top: 10px`))
+      check(...style(`${prefix}-block-end: 10px`, `${prefix}-bottom: 10px`))
+      check(...style(`${prefix}-inline: 10px`, `${prefix}-right: 10px; ${prefix}-left: 10px`))
+      check(...style(`${prefix}-block: 10px`, `${prefix}-top: 10px; ${prefix}-bottom: 10px`))
+    })
+
+    check(...style('border-inline-start: 10px', 'border-right: 10px'))
+    check(...style('border-inline-end: 10px', 'border-left: 10px'))
+    check(...style('border-block-start: 10px', 'border-top: 10px'))
+    check(...style('border-block-end: 10px', 'border-bottom: 10px'))
+    check(...style('border-inline: 10px', 'border-right: 10px; border-left: 10px'))
+    check(...style('border-block: 10px', 'border-top: 10px; border-bottom: 10px'))
+    ;['width', 'style', 'color'].forEach(unit => {
+      check(...style(`border-inline-start-${unit}: 10px`, `border-right-${unit}: 10px`))
+      check(...style(`border-inline-end-${unit}: 10px`, `border-left-${unit}: 10px`))
+      check(...style(`border-block-start-${unit}: 10px`, `border-top-${unit}: 10px`))
+      check(...style(`border-block-end-${unit}: 10px`, `border-bottom-${unit}: 10px`))
+      check(
+        ...style(
+          `border-inline-${unit}: 10px`,
+          `border-right-${unit}: 10px; border-left-${unit}: 10px`
+        )
+      )
+      check(
+        ...style(
+          `border-block-${unit}: 10px`,
+          `border-top-${unit}: 10px; border-bottom-${unit}: 10px`
+        )
+      )
+    })
+
+    check(...style('border-start-start-radius: 10px', 'border-top-right-radius: 10px'))
+    check(...style('border-start-end-radius: 10px', 'border-top-left-radius: 10px'))
+    check(...style('border-end-end-radius: 10px', 'border-bottom-left-radius: 10px'))
+    check(...style('border-end-start-radius: 10px', 'border-bottom-right-radius: 10px'))
+  })
+})

--- a/common/plugins/vitest.config.ts
+++ b/common/plugins/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/*.spec.ts'],
+    clearMocks: true
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   conventional-changelog-angular@7.0.0:
     hash: mnuz4pbg7c37j4ofaayqrj5u6y
@@ -291,6 +295,9 @@ importers:
       '@types/node':
         specifier: ^20.10.3
         version: 20.10.3
+      postcss:
+        specifier: ^8.4.32
+        version: 8.4.32
       tsup:
         specifier: ^8.0.1
         version: 8.0.1(postcss@8.4.32)(typescript@5.2.2)
@@ -11317,7 +11324,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
This plugin is used to transform logical style to its physical style to support the old version browsers.

e.g.

- `padding-inline-left: 10px` -> `padding-left: 10px`
- `inset-inline: 10px` -> `left: 10px; right: 10px`

