### PR TITLE
Update timeline.md

### DIFF
--- a/docs/en-US/component/timeline.md
+++ b/docs/en-US/component/timeline.md
@@ -103,7 +103,7 @@ type TimelineItemType = 'primary' | 'info' | 'success' | 'error' | 'warning' | '
 | ------------ | --------------------------------------------------------------------------- | --------------------------- | ----- |
 | signal-click | Emitted when a timeline node signal is clicked, returns the current `label` | `(label: string \| number)` | -     |
 
-### Textarea Slots
+### TimelineItem Slots
 
 | Name    | Description                       | Parameters | Since    |
 | ------- | --------------------------------- | ---------- | -------- |


### PR DESCRIPTION
### Description

There is a typo in the English documentation of the Timeline component.
There is a section named **Textarea Slots**. It should be named **TimelineItem Slots**.

This PR fix this.

### Linked Issues

None

### Additional Context

Only concern the english version of the documentation.
