### PR TITLE
feat(menu): add onlyOne prop

### DIFF
--- a/components/menu/menu-group.tsx
+++ b/components/menu/menu-group.tsx
@@ -66,6 +66,7 @@ const MenuGroup = defineComponent({
             children={item.children}
             route={item.route}
             meta={item.meta}
+            only-one={item.onlyOne}
           >
             {item.name ? callIfFunc(item.name) : item.label}
           </MenuItem>

--- a/components/menu/menu-rest.tsx
+++ b/components/menu/menu-rest.tsx
@@ -146,6 +146,7 @@ export default defineComponent({
           children={item.children}
           route={item.route}
           meta={item.meta}
+          only-one={item.onlyOne}
         >
           {item.name ? callIfFunc(item.name) : item.label}
         </MenuItem>

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -16,7 +16,7 @@ import {
 } from 'vue'
 
 import { emitEvent, useNameHelper, useProps } from '@vexip-ui/config'
-import { callIfFunc, isDefined } from '@vexip-ui/utils'
+import { callIfFunc, isBoolean, isDefined } from '@vexip-ui/utils'
 import MenuRest from './menu-rest'
 import { menuProps } from './props'
 import { MENU_STATE } from './symbol'
@@ -62,7 +62,8 @@ export default defineComponent({
       },
       router: null,
       manualRoute: false,
-      indent: null
+      indent: null,
+      onlyOne: false
     })
 
     const nh = useNameHelper('menu')
@@ -134,6 +135,8 @@ export default defineComponent({
         tooltipReverse: toRef(props, 'tooltipReverse'),
         transfer: toRef(props, 'transfer'),
         trigger: toRef(props, 'trigger'),
+        onlyOne: toRef(props, 'onlyOne'),
+        renderMenuItem,
         markerType,
         handleSelect,
         handleExpand,
@@ -317,7 +320,20 @@ export default defineComponent({
       }
     }
 
-    function renderMenuItem(item: MenuOptions) {
+    function renderMenuItem(menuItem: MenuOptions) {
+      const item =
+        (isBoolean(menuItem.onlyOne) ? menuItem.onlyOne : props.onlyOne) &&
+        menuItem.children?.length === 1
+          ? {
+              ...menuItem,
+              ...menuItem.children[0],
+              meta: {
+                _parent: menuItem.meta,
+                ...menuItem.children[0].meta
+              }
+            }
+          : menuItem
+
       return (
         <MenuItem
           label={item.label}
@@ -327,6 +343,7 @@ export default defineComponent({
           children={item.children}
           route={item.route}
           meta={item.meta}
+          only-one={item.onlyOne}
         >
           {item.name ? callIfFunc(item.name) : item.label}
         </MenuItem>
@@ -335,15 +352,13 @@ export default defineComponent({
 
     function renderMenus() {
       return menus.value.map(menu =>
-        menu.group
-          ? (
-            <MenuGroup key={menu.label} label={menu.name ? callIfFunc(menu.name) : menu.label}>
-              {menu.children?.length ? menu.children.map(renderMenuItem) : null}
-            </MenuGroup>
-            )
-          : (
-              renderMenuItem(menu)
-            )
+        menu.group ? (
+          <MenuGroup key={menu.label} label={menu.name ? callIfFunc(menu.name) : menu.label}>
+            {menu.children?.length ? menu.children.map(renderMenuItem) : null}
+          </MenuGroup>
+        ) : (
+          renderMenuItem(menu)
+        )
       )
     }
 

--- a/components/menu/props.ts
+++ b/components/menu/props.ts
@@ -20,6 +20,7 @@ export const menuProps = buildProps({
   router: Object as PropType<Router>,
   manualRoute: booleanProp,
   indent: [String, Number],
+  onlyOne: booleanProp,
   onSelect: eventProp<(label: string, meta: any) => void>(),
   onExpand: eventProp<(label: string, meta: any) => void>(),
   onReduce: eventProp<(label: string, meta: any) => void>()
@@ -39,6 +40,7 @@ export const menuItemProps = buildProps({
   meta: Object,
   children: Array as PropType<MenuOptions[]>,
   route: [String, Object] as PropType<RouteLocationRaw>,
+  onlyOne: booleanProp,
   onSelect: eventProp()
 })
 

--- a/components/menu/symbol.ts
+++ b/components/menu/symbol.ts
@@ -1,4 +1,4 @@
-import type { ComponentPublicInstance, InjectionKey } from 'vue'
+import type { ComponentPublicInstance, InjectionKey, VNode } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 import type { IconMinorProps } from '@/components/icon'
 
@@ -14,6 +14,7 @@ export interface MenuOptions {
   group?: boolean,
   meta?: Record<string, any>,
   route?: RouteLocationRaw,
+  onlyOne?: boolean,
   children?: MenuOptions[]
 }
 
@@ -46,6 +47,8 @@ export interface MenuState {
   isReduced: boolean,
   transfer: boolean | string,
   trigger: 'hover' | 'click',
+  onlyOne: boolean,
+  renderMenuItem(item: MenuOptions): VNode,
   markerType: MenuMarkerType,
   handleSelect(label: string, meta: Record<string, any>, route?: RouteLocationRaw): void,
   handleExpand(label: string, expanded: boolean, meta: Record<string, any>): void,

--- a/components/menu/tests/menu.spec.tsx
+++ b/components/menu/tests/menu.spec.tsx
@@ -255,6 +255,51 @@ describe('Menu', () => {
     expect(wrapper.findAll('.vxp-menu__item')[3].classes()).toContain('vxp-menu__item--disabled')
   })
 
+  it.only('use onlyOne', async () => {
+    const options = [
+      {
+        label: 'g1',
+        group: true,
+        children: [
+          {
+            label: '1',
+            name: 'l1',
+            icon: Home,
+            children: [
+              { label: '1-1', meta: { foo: '1-1' } },
+              { label: '1-2', meta: { foo: '1-2' } }
+            ]
+          },
+          {
+            label: '2',
+            name: 'l2',
+            icon: Home,
+            children: [{ label: '2-1', meta: { foo: '2-1' } }]
+          },
+          {
+            label: '3',
+            name: 'l3',
+            icon: Home,
+            onlyOne: false,
+            children: [{ label: '3-1', meta: { foo: '3-1' } }]
+          }
+        ]
+      },
+      {
+        label: '2',
+        icon: User,
+        disabled: true
+      }
+    ]
+    const wrapper = mount(() => <Menu options={options} onlyOne></Menu>)
+
+    const items = wrapper.findAll('.vxp-menu__item')
+
+    expect(items[3].find('.vxp-menu__list').exists()).toBe(false)
+    expect(items[3].text()).toBe('2-1')
+    expect(items[5].exists()).toBe(true)
+  })
+
   it('use router', async () => {
     const testRoute = {
       path: 'c1',

--- a/docs/demos/menu/options/demo.en-US.vue
+++ b/docs/demos/menu/options/demo.en-US.vue
@@ -45,18 +45,31 @@ const options: MenuOptions[] = [
       {
         label: '4',
         name: () => 'Menu 4',
-        icon: () => h(Icon, { icon: User })
+        icon: () => h(Icon, { icon: User }),
+        meta: {
+          parent: true,
+          label: '4'
+        }
       },
       {
         label: '5',
         name: 'Menu 5',
-        icon: Marker
+        icon: Marker,
+        children: [{ label: '5-1', name: 'Child Menu 5-1', meta: { child: true } }]
+      },
+      {
+        label: '6',
+        name: 'Menu 6',
+        icon: Marker,
+        meta: { parent: true },
+        onlyOne: true,
+        children: [{ label: '6-1', name: 'Child Menu 6-1', meta: { child: true } }]
       }
     ]
   }
 ]
 
-function handleSelect(label: string) {
-  console.info(label)
+function handleSelect(label: string, meta: object) {
+  console.info(label, meta)
 }
 </script>

--- a/docs/demos/menu/options/demo.zh-CN.vue
+++ b/docs/demos/menu/options/demo.zh-CN.vue
@@ -45,18 +45,32 @@ const options: MenuOptions[] = [
       {
         label: '4',
         name: () => '菜单 4',
-        icon: () => h(Icon, { icon: User })
+        icon: () => h(Icon, { icon: User }),
+        meta: {
+          parent: true,
+          label: '4'
+        }
       },
       {
         label: '5',
         name: '菜单 5',
-        icon: Marker
+        icon: Marker,
+        meta: { parent: true },
+        children: [{ label: '5-1', name: '子菜单 5-1', meta: { child: true } }]
+      },
+      {
+        label: '6',
+        name: '菜单 6',
+        icon: Marker,
+        meta: { parent: true },
+        onlyOne: true,
+        children: [{ label: '6-1', name: '子菜单 6-1', meta: { child: true } }]
       }
     ]
   }
 ]
 
-function handleSelect(label: string) {
-  console.info(label)
+function handleSelect(label: string, meta: object) {
+  console.info(label, meta)
 }
 </script>

--- a/docs/en-US/component/menu.md
+++ b/docs/en-US/component/menu.md
@@ -88,21 +88,22 @@ interface MenuOptions {
 
 ### Menu Props
 
-| Name          | Type                                               | Description                                                                                                                 | Default      | Since   |
-| ------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------ | ------- |
-| active        | `string`                                           | Set the default active menu                                                                                                 | `null`       | -       |
-| accordion     | `boolean`                                          | Set whether to enable accordion mode. In this mode, only one menu at the same level can be expanded                         | `0`          | -       |
-| marker-type   | `'top' \| 'right' \| 'bottom' \| 'left' \| 'none'` | Set the marker type of the selected menu                                                                                    | `'right'`    | -       |
-| reduced       | `boolean`                                          | Set whether the menu is reduced                                                                                             | `false`      | -       |
-| horizontal    | `boolean`                                          | Set whether the menu is horizontal                                                                                          | `false`      | -       |
-| group-type    | `'collapse' \| 'dropdown'`                         | Submenu form in expanded state                                                                                              | `'collapse'` | -       |
-| theme         | `'light' \| 'dark'`                                | set the theme of the menu                                                                                                   | `'light'`    | -       |
-| tooltip-theme | `'light' \| 'dark'`                                | Set the theme of the menu bubble tip                                                                                        | `'dark'`     | -       |
-| transfer      | `boolean \| string`                                | Set the `transfer` property of the MenuItem under it, the priority is higher when the MenuItem sets this property alone     | `false`      | -       |
-| options       | `MenuOptions[]`                                    | Set configuration of the menu                                                                                               | `[]`         | `2.0.0` |
-| router        | `Router`                                           | Set the Router object and its routes will be parsed automatically and generate the menus, will use `options` to parse first | `null`       | `2.0.0` |
-| manual-route  | `boolean`                                          | Whether it is set to manual route mode, route changes will not be processed automatically after it is enabled               | `false`      | `2.0.0` |
-| indent        | `string \| number`                                 | Set the base indentation distance of each label menu item                                                                   | `null`       | `2.1.2` |
+| Name          | Type                                               | Description                                                                                                                 | Default      | Since    |
+| ------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------ | -------- |
+| active        | `string`                                           | Set the default active menu                                                                                                 | `null`       | -        |
+| accordion     | `boolean`                                          | Set whether to enable accordion mode. In this mode, only one menu at the same level can be expanded                         | `0`          | -        |
+| marker-type   | `'top' \| 'right' \| 'bottom' \| 'left' \| 'none'` | Set the marker type of the selected menu                                                                                    | `'right'`    | -        |
+| reduced       | `boolean`                                          | Set whether the menu is reduced                                                                                             | `false`      | -        |
+| horizontal    | `boolean`                                          | Set whether the menu is horizontal                                                                                          | `false`      | -        |
+| group-type    | `'collapse' \| 'dropdown'`                         | Submenu form in expanded state                                                                                              | `'collapse'` | -        |
+| theme         | `'light' \| 'dark'`                                | set the theme of the menu                                                                                                   | `'light'`    | -        |
+| tooltip-theme | `'light' \| 'dark'`                                | Set the theme of the menu bubble tip                                                                                        | `'dark'`     | -        |
+| transfer      | `boolean \| string`                                | Set the `transfer` property of the MenuItem under it, the priority is higher when the MenuItem sets this property alone     | `false`      | -        |
+| options       | `MenuOptions[]`                                    | Set configuration of the menu                                                                                               | `[]`         | `2.0.0`  |
+| router        | `Router`                                           | Set the Router object and its routes will be parsed automatically and generate the menus, will use `options` to parse first | `null`       | `2.0.0`  |
+| manual-route  | `boolean`                                          | Whether it is set to manual route mode, route changes will not be processed automatically after it is enabled               | `false`      | `2.0.0`  |
+| indent        | `string \| number`                                 | Set the base indentation distance of each label menu item                                                                   | `null`       | `2.1.2`  |
+| onlyOne       | `boolean`                                          | When `options` has only one item in `children`, the only item overrides the parent item                                     | `false`      | `2.3.12` |
 
 ### Menu Events
 
@@ -112,6 +113,8 @@ interface MenuOptions {
 | expand | Emitted when the menu is expanded (submenu), returns the label of the menu of the expanded group         | `(label: string, meta: Record<string, any>)` | -     |
 | reduce | Emitted when the menu is collapsed group (submenu), returns the label of the menu in the collapsed group | `(label: string, meta: Record<string, any>)` | -     |
 
+> `_parent` in `meta` is the original parent `meta`
+
 ### Menu Methods
 
 | Name              | Description                            | Parameters                | Since   |
@@ -120,17 +123,18 @@ interface MenuOptions {
 
 ### MenuItem Props
 
-| Name            | Type                  | Description                                                                                                                                                                                                              | Default | Since   |
-| --------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------- |
-| label           | `string`              | Unique identifier for the menu                                                                                                                                                                                           | `null`  | -       |
-| icon            | `string`              | Set the icon of the menu, the icon of the menu shrinking state needs to be set through this property or the slot with the same name                                                                                      | `null`  | -       |
-| icon-props      | `IconProps`           | Set the props of the menu icon                                                                                                                                                                                           | `null`  | `2.0.0` |
-| disabled        | `boolean`             | Set whether the menu is disabled                                                                                                                                                                                         | `false` | -       |
-| transfer        | `boolean \| string`   | When the child element is in the drop-down state, set the rendering position of its child element. When set to `true`, it will render to `<body>` by default                                                             | `false` | -       |
-| transition-name | `string`              | When the child element is in the drop-down state, set the transition effect of the child element. If it is not set, it will take the value of `'vxp-drop'` or `'vxp-zoom'` according to whether it is a horizontal menu. | `null`  | -       |
-| meta            | `Record<string, any>` | Set meta data of the menu                                                                                                                                                                                                | `null`  | `2.0.0` |
-| children        | `MenuOptions[]`       | Set configuration of the menu children                                                                                                                                                                                   | `[]`    | `2.0.0` |
-| route           | `RouteLocationRaw`    | Set the route associated with the menu. If the Router object is set, it will automatically handle the change of the route by default                                                                                     | `null`  | `2.0.0` |
+| Name            | Type                  | Description                                                                                                                                                                                                              | Default | Since    |
+| --------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
+| label           | `string`              | Unique identifier for the menu                                                                                                                                                                                           | `null`  | -        |
+| icon            | `string`              | Set the icon of the menu, the icon of the menu shrinking state needs to be set through this property or the slot with the same name                                                                                      | `null`  | -        |
+| icon-props      | `IconProps`           | Set the props of the menu icon                                                                                                                                                                                           | `null`  | `2.0.0`  |
+| disabled        | `boolean`             | Set whether the menu is disabled                                                                                                                                                                                         | `false` | -        |
+| transfer        | `boolean \| string`   | When the child element is in the drop-down state, set the rendering position of its child element. When set to `true`, it will render to `<body>` by default                                                             | `false` | -        |
+| transition-name | `string`              | When the child element is in the drop-down state, set the transition effect of the child element. If it is not set, it will take the value of `'vxp-drop'` or `'vxp-zoom'` according to whether it is a horizontal menu. | `null`  | -        |
+| meta            | `Record<string, any>` | Set meta data of the menu                                                                                                                                                                                                | `null`  | `2.0.0`  |
+| children        | `MenuOptions[]`       | Set configuration of the menu children                                                                                                                                                                                   | `[]`    | `2.0.0`  |
+| route           | `RouteLocationRaw`    | Set the route associated with the menu. If the Router object is set, it will automatically handle the change of the route by default                                                                                     | `null`  | `2.0.0`  |
+| onlyOne         | `boolean`             | When `children` has only one item, the only child item overrides the parent item; it has higher priority than `menu.onlyOne`                                                                                             | `null`  | `2.3.12` |
 
 ### MenuItem Slots
 

--- a/docs/zh-CN/component/menu.md
+++ b/docs/zh-CN/component/menu.md
@@ -88,21 +88,22 @@ interface MenuOptions {
 
 ### Menu 属性
 
-| 名称          | 类型                                               | 说明                                                                           | 默认值       | 始于    |
-| ------------- | -------------------------------------------------- | ------------------------------------------------------------------------------ | ------------ | ------- |
-| active        | `string`                                           | 设置默认激活的菜单                                                             | `null`       | -       |
-| accordion     | `boolean`                                          | 设置是否开启手风琴模式，该模式下同级菜单只能展开一个                           | `0`          | -       |
-| marker-type   | `'top' \| 'right' \| 'bottom' \| 'left' \| 'none'` | 设置选中菜单的标记的类型                                                       | `'right'`    | -       |
-| reduced       | `boolean`                                          | 设置菜单是否收缩                                                               | `false`      | -       |
-| horizontal    | `boolean`                                          | 设置是否为横向菜单                                                             | `false`      | -       |
-| group-type    | `'collapse' \| 'dropdown'`                         | 在展开状态时子菜单的形式                                                       | `'collapse'` | -       |
-| theme         | `'light' \| 'dark'`                                | 设置菜单的主题                                                                 | `'light'`    | -       |
-| tooltip-theme | `'light' \| 'dark'`                                | 设置菜单气泡提示的主题                                                         | `'dark'`     | -       |
-| transfer      | `boolean \| string`                                | 设置其下 MenuItem 的 `transfer` 属性，当 MenuItem 单独设置了该属性时优先级更高 | `false`      | -       |
-| options       | `MenuOptions[]`                                    | 设置菜单的配置                                                                 | `[]`         | `2.0.0` |
-| router        | `Router`                                           | 设置 Router 对象，并自动解析生成菜单，会优先使用 `options` 解析                | `null`       | `2.0.0` |
-| manual-route  | `boolean`                                          | 设置是否为手动路由模式，开启后将不会自动处理路由变化                           | `false`      | `2.0.0` |
-| indent        | `string \| number`                                 | 置每层菜单的基础缩进距离                                                       | `null`       | `2.1.2` |
+| 名称          | 类型                                               | 说明                                                                           | 默认值       | 始于     |
+| ------------- | -------------------------------------------------- | ------------------------------------------------------------------------------ | ------------ | -------- |
+| active        | `string`                                           | 设置默认激活的菜单                                                             | `null`       | -        |
+| accordion     | `boolean`                                          | 设置是否开启手风琴模式，该模式下同级菜单只能展开一个                           | `0`          | -        |
+| marker-type   | `'top' \| 'right' \| 'bottom' \| 'left' \| 'none'` | 设置选中菜单的标记的类型                                                       | `'right'`    | -        |
+| reduced       | `boolean`                                          | 设置菜单是否收缩                                                               | `false`      | -        |
+| horizontal    | `boolean`                                          | 设置是否为横向菜单                                                             | `false`      | -        |
+| group-type    | `'collapse' \| 'dropdown'`                         | 在展开状态时子菜单的形式                                                       | `'collapse'` | -        |
+| theme         | `'light' \| 'dark'`                                | 设置菜单的主题                                                                 | `'light'`    | -        |
+| tooltip-theme | `'light' \| 'dark'`                                | 设置菜单气泡提示的主题                                                         | `'dark'`     | -        |
+| transfer      | `boolean \| string`                                | 设置其下 MenuItem 的 `transfer` 属性，当 MenuItem 单独设置了该属性时优先级更高 | `false`      | -        |
+| options       | `MenuOptions[]`                                    | 设置菜单的配置                                                                 | `[]`         | `2.0.0`  |
+| router        | `Router`                                           | 设置 Router 对象，并自动解析生成菜单，会优先使用 `options` 解析                | `null`       | `2.0.0`  |
+| manual-route  | `boolean`                                          | 设置是否为手动路由模式，开启后将不会自动处理路由变化                           | `false`      | `2.0.0`  |
+| indent        | `string \| number`                                 | 置每层菜单的基础缩进距离                                                       | `null`       | `2.1.2`  |
+| onlyOne       | `boolean`                                          | `options` 的 `children` 只有唯一项时，唯一子项覆盖父项                         | `false`      | `2.3.12` |
 
 ### Menu 事件
 
@@ -112,6 +113,8 @@ interface MenuOptions {
 | expand | 当菜单被展开组 (子菜单) 时触发，返回被展开组的菜单的 label | `(label: string, meta: Record<string, any>)` | -    |
 | reduce | 当菜单被收起组 (子菜单) 时触发，返回被收起组的菜单的 label | `(label: string, meta: Record<string, any>)` | -    |
 
+> `meta` 中 `_parent` 是原父项 `meta`
+
 ### Menu 方法
 
 | 名称              | 说明               | 签名                      | 始于    |
@@ -120,17 +123,18 @@ interface MenuOptions {
 
 ### MenuItem 属性
 
-| 名称            | 类型                  | 说明                                                                                                            | 默认值  | 始于    |
-| --------------- | --------------------- | --------------------------------------------------------------------------------------------------------------- | ------- | ------- |
-| label           | `string`              | 菜单的唯一标识                                                                                                  | `null`  | -       |
-| icon            | `string`              | 设置菜单的图标，菜单收缩状态的图标需通过该属性或同名插槽设置                                                    | `null`  | -       |
-| icon-props      | `IconProps`           | 设置菜单图标的属性                                                                                              | `null`  | `2.0.0` |
-| disabled        | `boolean`             | 设置菜单是否为禁用状态                                                                                          | `false` | -       |
-| transfer        | `boolean \| string`   | 当子元素处于下拉状态时，设置其子元素的渲染位置，设置为 `true` 时默认渲染至 `<body>`                             | `false` | -       |
-| transition-name | `string`              | 当子元素处于下拉状态时，设置子元素的过渡效果，未设置时会根据是否为横向菜单分别取值 `'vxp-drop'` 或 `'vxp-zoom'` | `null`  | -       |
-| meta            | `Record<string, any>` | 设置菜单的元数据                                                                                                | `null`  | `2.0.0` |
-| children        | `MenuOptions[]`       | 设置菜单的子级配置                                                                                              | `[]`    | `2.0.0` |
-| route           | `RouteLocationRaw`    | 设置菜单关联的路由，如果设置的 Router 对象默认情况下会自动处理路由的变化                                        | `null`  | `2.0.0` |
+| 名称            | 类型                  | 说明                                                                                                            | 默认值  | 始于     |
+| --------------- | --------------------- | --------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| label           | `string`              | 菜单的唯一标识                                                                                                  | `null`  | -        |
+| icon            | `string`              | 设置菜单的图标，菜单收缩状态的图标需通过该属性或同名插槽设置                                                    | `null`  | -        |
+| icon-props      | `IconProps`           | 设置菜单图标的属性                                                                                              | `null`  | `2.0.0`  |
+| disabled        | `boolean`             | 设置菜单是否为禁用状态                                                                                          | `false` | -        |
+| transfer        | `boolean \| string`   | 当子元素处于下拉状态时，设置其子元素的渲染位置，设置为 `true` 时默认渲染至 `<body>`                             | `false` | -        |
+| transition-name | `string`              | 当子元素处于下拉状态时，设置子元素的过渡效果，未设置时会根据是否为横向菜单分别取值 `'vxp-drop'` 或 `'vxp-zoom'` | `null`  | -        |
+| meta            | `Record<string, any>` | 设置菜单的元数据                                                                                                | `null`  | `2.0.0`  |
+| children        | `MenuOptions[]`       | 设置菜单的子级配置                                                                                              | `[]`    | `2.0.0`  |
+| route           | `RouteLocationRaw`    | 设置菜单关联的路由，如果设置的 Router 对象默认情况下会自动处理路由的变化                                        | `null`  | `2.0.0`  |
+| onlyOne         | `boolean`             | `children` 只有唯一项时，唯一子项覆盖父项; 优先级高于 `menu.onlyOne`                                            | `null`  | `2.3.12` |
 
 ### MenuItem 插槽
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/vexip-ui/vexip-ui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`menu` 配置 `onlyOne` 时，菜单中的 `children` 只有唯一项只渲染唯一子项
`menu-item` 配置 `onlyOne` 时，覆盖 `menu.onlyOne` 配置；默认 `null`

### Linked Issues

Fix #488 

### Additional Context

<!-- Any other context or screenshots about the PR here. -->
