### PR TITLE
fix(modal\drawer): 修复 drawer 组件打开时导致内部嵌入组件渲染两次的问题

### DIFF
--- a/components/drawer/drawer.vue
+++ b/components/drawer/drawer.vue
@@ -3,7 +3,7 @@ import { Button } from '@/components/button'
 import { Icon } from '@/components/icon'
 import { Masker } from '@/components/masker'
 
-import { computed, nextTick, reactive, ref, shallowReadonly, toRef, watch } from 'vue'
+import { computed, nextTick, onMounted, reactive, ref, shallowReadonly, toRef, watch } from 'vue'
 
 import {
   createSizeProp,
@@ -87,6 +87,7 @@ const currentHeight = ref(props.height)
 const wrapper = ref<HTMLElement>()
 
 const idIndex = `${getGlobalCount()}`
+const rendered = ref(false)
 
 const { target: resizer, moving: resizing } = useMoving({
   onStart: (state, event) => {
@@ -200,6 +201,10 @@ const bodyId = computed(() => `${nh.bs(idIndex)}__body`)
 watch(
   () => props.active,
   value => {
+    console.log(value, 'value')
+    if (value) {
+      rendered.value = true
+    }
     currentActive.value = value
   }
 )
@@ -215,6 +220,11 @@ watch(
     currentHeight.value = value
   }
 )
+onMounted(() => {
+  if (props.active) {
+    rendered.value = true
+  }
+})
 
 defineExpose({
   resizing,
@@ -341,7 +351,7 @@ function handleCancel() {
             </button>
           </slot>
         </div>
-        <div :id="bodyId" :class="nh.be('content')">
+        <div v-if="rendered" :id="bodyId" :class="nh.be('content')">
           <slot v-bind="slotParams"></slot>
         </div>
         <div v-if="props.footer || $slots.footer" :class="nh.be('footer')">

--- a/components/modal/modal.vue
+++ b/components/modal/modal.vue
@@ -4,7 +4,7 @@ import { Icon } from '@/components/icon'
 import { Masker } from '@/components/masker'
 import { ResizeObserver } from '@/components/resize-observer'
 
-import { computed, nextTick, reactive, ref, shallowReadonly, toRef, watch } from 'vue'
+import { computed, nextTick, onMounted, reactive, ref, shallowReadonly, toRef, watch } from 'vue'
 
 import {
   createSizeProp,
@@ -112,6 +112,8 @@ const transformed = ref(false)
 const masker = ref<MaskerExposed>()
 const wrapper = ref<HTMLElement>()
 const footer = ref<HTMLElement>()
+
+const rendered = ref(false)
 
 const uselessTop = computed(() => {
   return props.top === 'auto' && isSpecified(props.bottom) && isSpecified(props.height)
@@ -314,6 +316,9 @@ for (const style of Object.keys(rect) as Array<keyof typeof rect>) {
 watch(
   () => props.active,
   value => {
+    if (value) {
+      rendered.value = true
+    }
     currentActive.value = value
   }
 )
@@ -354,6 +359,11 @@ defineExpose({
   handleConfirm,
   handleCancel,
   handleClose
+})
+onMounted(() => {
+  if (props.active) {
+    rendered.value = true
+  }
 })
 
 const slotParams = shallowReadonly(
@@ -563,6 +573,7 @@ function handleModalResize(entry: ResizeObserverEntry) {
               </slot>
             </div>
             <div
+              v-if="rendered"
               :id="bodyId"
               :class="nh.be('content')"
               :style="{


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/vexip-ui/vexip-ui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Clear and concise description of what the PR is solving. -->

### Linked Issues

<!-- Fix #123. Fix #666. -->
Fix #502 
### Additional Context

<!-- Any other context or screenshots about the PR here. -->
